### PR TITLE
Add an optional name to spies

### DIFF
--- a/chai-spies.js
+++ b/chai-spies.js
@@ -45,8 +45,13 @@
      * @api public
      */
 
-    chai.spy = function (fn) {
-      if (!fn) fn = function () {};
+    chai.spy = function (name, fn) {
+      if (typeof name === 'function') {
+        fn = name;
+        name = undefined;
+      }
+
+      fn = fn || function () {};
 
       function makeProxy (length, fn) {
         switch (length) {
@@ -75,6 +80,7 @@
       proxy.__spy = {
           calls: []
         , called: false
+        , name: name
       };
 
       return proxy;
@@ -243,5 +249,4 @@
     Assertion.overwriteMethod('below', below);
     Assertion.overwriteMethod('lt', below);
   };
-
 });

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -29,8 +29,13 @@ module.exports = function (chai, _) {
    * @api public
    */
 
-  chai.spy = function (fn) {
-    if (!fn) fn = function () {};
+  chai.spy = function (name, fn) {
+    if (typeof name === 'function') {
+      fn = name;
+      name = undefined;
+    }
+
+    fn = fn || function () {};
 
     function makeProxy (length, fn) {
       switch (length) {
@@ -59,6 +64,7 @@ module.exports = function (chai, _) {
     proxy.__spy = {
         calls: []
       , called: false
+      , name: name
     };
 
     return proxy;

--- a/test/spies.js
+++ b/test/spies.js
@@ -8,6 +8,28 @@ var should = chai.should();
 
 describe('Chai Spies', function () {
 
+  describe('name', function() {
+    it('defaults to undefined', function() {
+      chai.expect(chai.spy().__spy.name).to.equal(undefined);
+    });
+
+    it('exposes the name', function() {
+      chai.expect(chai.spy('007').__spy.name).to.equal('007');
+    });
+
+    it('executes the function sent to the spy', function() {
+      var spy = chai.spy()
+      chai.spy('007', spy)();
+      spy.should.have.been.called.once
+    });
+  });
+
+  it('should invoke the function sent to the spy', function() {
+    var spy = chai.spy()
+    chai.spy(spy)()
+    spy.should.have.been.called.once
+  });
+
   it('should know when obj is a spy', function () {
     var spy = chai.spy();
     spy.should.be.spy;


### PR DESCRIPTION
To be able to separate them in the output in the console in situation where several spies are in use at the same time.
