### PR TITLE
Make the output in console look nicer

### DIFF
--- a/chai-spies.js
+++ b/chai-spies.js
@@ -77,6 +77,16 @@
       });
 
       proxy.prototype = fn.prototype;
+      proxy.toString = function toString() {
+        var l = this.__spy.calls.length;
+        var s = "{ Spy";
+        if (this.__spy.name)
+          s += " '" + this.__spy.name + "'";
+        if (l > 0)
+          s += ", " + l + " call" + (l > 1 ? 's' : '');
+        s += " }";
+        return s;
+      };
       proxy.__spy = {
           calls: []
         , called: false
@@ -101,8 +111,8 @@
     Assertion.addProperty('spy', function () {
       this.assert(
           'undefined' !== typeof this._obj.__spy
-        , 'expected #{this} to be a spy'
-        , 'expected #{this} to not be a spy');
+        , 'expected ' + this._obj + ' to be a spy'
+        , 'expected ' + this._obj + ' to not be a spy');
       return this;
     });
 
@@ -121,8 +131,8 @@
 
         this.assert(
             this._obj.__spy.called === true
-          , 'expected #{this} to have been called'
-          , 'expected #{this} to not have been called'
+          , 'expected ' + this._obj + ' to have been called'
+          , 'expected ' + this._obj + ' to not have been called'
         );
 
         return this;
@@ -144,8 +154,8 @@
       new Assertion(this._obj).to.be.spy;
       this.assert(
           this._obj.__spy.calls.length === 1
-        , 'expected #{this} to have been called once but got #{act}'
-        , 'expected #{this} to not have been called once'
+        , 'expected ' + this._obj + ' to have been called once but got #{act}'
+        , 'expected ' + this._obj + ' to not have been called once'
         , 1
         , this._obj.__spy.calls.length );
     });
@@ -162,8 +172,8 @@
       new Assertion(this._obj).to.be.spy;
       this.assert(
           this._obj.__spy.calls.length === 2
-        , 'expected #{this} to have been called once but got #{act}'
-        , 'expected #{this} to not have been called once'
+        , 'expected ' + this._obj + ' to have been called once but got #{act}'
+        , 'expected ' + this._obj + ' to not have been called once'
         , 2
         , this._obj.__spy.calls.length
       );
@@ -182,8 +192,8 @@
       new Assertion(this._obj).to.be.spy;
       this.assert(
           this._obj.__spy.calls.length === n
-        , 'expected #{this} to have been called #{exp} times but got #{act}'
-        , 'expected #{this} to not have been called #{exp} times'
+        , 'expected ' + this._obj + ' to have been called #{exp} times but got #{act}'
+        , 'expected ' + this._obj + ' to not have been called #{exp} times'
         , n
         , this._obj.__spy.calls.length
       );
@@ -205,8 +215,8 @@
 
           this.assert(
               this._obj.__spy.calls.length > n
-            , 'expected #{this} to have been called more than #{exp} times but got #{act}'
-            , 'expected #{this} to have been called no more than than #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called more than #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called no more than than #{exp} times but got #{act}'
             , n
             , this._obj.__spy.calls.length
           );
@@ -235,8 +245,8 @@
 
           this.assert(
               this._obj.__spy.calls.length <  n
-            , 'expected #{this} to have been called less than #{exp} times but got #{act}'
-            , 'expected #{this} to have been called at least #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called less than #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called at least #{exp} times but got #{act}'
             , n
             , this._obj.__spy.calls.length
           );

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -61,6 +61,16 @@ module.exports = function (chai, _) {
     });
 
     proxy.prototype = fn.prototype;
+    proxy.toString = function toString() {
+      var l = this.__spy.calls.length;
+      var s = "{ Spy";
+      if (this.__spy.name)
+        s += " '" + this.__spy.name + "'";
+      if (l > 0)
+        s += ", " + l + " call" + (l > 1 ? 's' : '');
+      s += " }";
+      return s;
+    };
     proxy.__spy = {
         calls: []
       , called: false
@@ -85,8 +95,8 @@ module.exports = function (chai, _) {
   Assertion.addProperty('spy', function () {
     this.assert(
         'undefined' !== typeof this._obj.__spy
-      , 'expected #{this} to be a spy'
-      , 'expected #{this} to not be a spy');
+      , 'expected ' + this._obj + ' to be a spy'
+      , 'expected ' + this._obj + ' to not be a spy');
     return this;
   });
 
@@ -105,8 +115,8 @@ module.exports = function (chai, _) {
 
       this.assert(
           this._obj.__spy.called === true
-        , 'expected #{this} to have been called'
-        , 'expected #{this} to not have been called'
+        , 'expected ' + this._obj + ' to have been called'
+        , 'expected ' + this._obj + ' to not have been called'
       );
 
       return this;
@@ -128,8 +138,8 @@ module.exports = function (chai, _) {
     new Assertion(this._obj).to.be.spy;
     this.assert(
         this._obj.__spy.calls.length === 1
-      , 'expected #{this} to have been called once but got #{act}'
-      , 'expected #{this} to not have been called once'
+      , 'expected ' + this._obj + ' to have been called once but got #{act}'
+      , 'expected ' + this._obj + ' to not have been called once'
       , 1
       , this._obj.__spy.calls.length );
   });
@@ -146,8 +156,8 @@ module.exports = function (chai, _) {
     new Assertion(this._obj).to.be.spy;
     this.assert(
         this._obj.__spy.calls.length === 2
-      , 'expected #{this} to have been called once but got #{act}'
-      , 'expected #{this} to not have been called once'
+      , 'expected ' + this._obj + ' to have been called once but got #{act}'
+      , 'expected ' + this._obj + ' to not have been called once'
       , 2
       , this._obj.__spy.calls.length
     );
@@ -166,8 +176,8 @@ module.exports = function (chai, _) {
     new Assertion(this._obj).to.be.spy;
     this.assert(
         this._obj.__spy.calls.length === n
-      , 'expected #{this} to have been called #{exp} times but got #{act}'
-      , 'expected #{this} to not have been called #{exp} times'
+      , 'expected ' + this._obj + ' to have been called #{exp} times but got #{act}'
+      , 'expected ' + this._obj + ' to not have been called #{exp} times'
       , n
       , this._obj.__spy.calls.length
     );
@@ -189,8 +199,8 @@ module.exports = function (chai, _) {
 
         this.assert(
             this._obj.__spy.calls.length > n
-          , 'expected #{this} to have been called more than #{exp} times but got #{act}'
-          , 'expected #{this} to have been called no more than than #{exp} times but got #{act}'
+          , 'expected ' + this._obj + ' to have been called more than #{exp} times but got #{act}'
+          , 'expected ' + this._obj + ' to have been called no more than than #{exp} times but got #{act}'
           , n
           , this._obj.__spy.calls.length
         );
@@ -219,8 +229,8 @@ module.exports = function (chai, _) {
 
         this.assert(
             this._obj.__spy.calls.length <  n
-          , 'expected #{this} to have been called less than #{exp} times but got #{act}'
-          , 'expected #{this} to have been called at least #{exp} times but got #{act}'
+          , 'expected ' + this._obj + ' to have been called less than #{exp} times but got #{act}'
+          , 'expected ' + this._obj + ' to have been called at least #{exp} times but got #{act}'
           , n
           , this._obj.__spy.calls.length
         );

--- a/test/spies.js
+++ b/test/spies.js
@@ -24,6 +24,28 @@ describe('Chai Spies', function () {
     });
   });
 
+  describe('textual representation', function() {
+
+    it('should print out nice', function() {
+      chai.spy().toString().should.equal("{ Spy }");
+    });
+    it('should show the name', function() {
+      chai.spy('Nikita').toString().should.equal("{ Spy 'Nikita' }");
+    });
+    it('should expose number of invokations', function() {
+      var spy = chai.spy()
+      spy(); // 1
+      spy(); // 2
+      spy.toString().should.equal("{ Spy, 2 calls }");
+    });
+    it('should expose name and number of invokations', function() {
+      var spy = chai.spy('Nikita')
+      spy(); // 1
+      spy.toString().should.equal("{ Spy 'Nikita', 1 call }");
+    });
+
+  });
+
   it('should invoke the function sent to the spy', function() {
     var spy = chai.spy()
     chai.spy(spy)()


### PR DESCRIPTION
Override the toString method for spies so that the output in the console will be more understandable.

Dependent on #3
