### PR TITLE
Typo: error output when spy has not been called

### DIFF
--- a/chai-spies.js
+++ b/chai-spies.js
@@ -141,7 +141,7 @@
         this.assert(
             spy.called === true
           , 'expected ' + this._obj + ' to have been called'
-          , 'expected ' + this._ojb + ' to not have been called'
+          , 'expected ' + this._obj + ' to not have been called'
         );
       }
     }

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -125,7 +125,7 @@ module.exports = function (chai, _) {
       this.assert(
           spy.called === true
         , 'expected ' + this._obj + ' to have been called'
-        , 'expected ' + this._ojb + ' to not have been called'
+        , 'expected ' + this._obj + ' to not have been called'
       );
     }
   }


### PR DESCRIPTION
Fix error output when the spy has not been called.