### PR TITLE
Implemented support for spy.on and spy.object methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ ee.on('some event', spy);
 // or use without original
 var spy_again = chai.spy();
 ee.on('some other event', spy_again);
+
+//or you can track object methods calls
+var array = [ 1, 2, 3 ];
+chai.spy.on(array, 'push');
+array.push(5);
+
+//or you can create spy object
+var object = chai.spy.object([ 'push', 'pop' ]);
+object.push(5);
 ```
 
 ### Assertions

--- a/chai-spies.js
+++ b/chai-spies.js
@@ -97,6 +97,57 @@
     }
 
     /**
+     * # chai.spy.on (function)
+     *
+     * Wraps an object method into spy. All calls will
+     * pass through to the original function.
+     *
+     *      var spy = chai.spy.on(Array, 'isArray');
+     *
+     * @param {Object} object
+     * @param {String} method name to spy on
+     * @returns function to actually call
+     * @api public
+     */
+
+    chai.spy.on = function (object, methodName) {
+      object[methodName] = chai.spy(object[methodName]);
+
+      return object[methodName];
+    };
+
+    /**
+     * # chai.spy.object (function)
+     *
+     * Creates an object with spied methods.
+     *
+     *      var object = chai.spy.object('Array', [ 'push', 'pop' ]);
+     *
+     * @param {Array|Object} method names or method definitions
+     * @returns object with spied methods
+     * @api public
+     */
+
+    chai.spy.object = function (name, methods) {
+      var defs = {};
+
+      if (name && typeof name === 'object') {
+        methods = name;
+        name = 'object';
+      }
+
+      if (methods && !Array.isArray(methods)) {
+        defs = methods;
+        methods = Object.keys(methods);
+      }
+
+      return methods.reduce(function (object, methodName) {
+        object[methodName] = chai.spy(name + '.' + methodName, defs[methodName]);
+        return object;
+      }, {});
+    };
+
+    /**
      * # spy
      *
      * Assert the the object in question is an chai.spy
@@ -182,8 +233,8 @@
       new Assertion(this._obj).to.be.spy;
       this.assert(
           this._obj.__spy.calls.length === 2
-        , 'expected ' + this._obj + ' to have been called once but got #{act}'
-        , 'expected ' + this._obj + ' to not have been called once'
+        , 'expected ' + this._obj + ' to have been called twice but got #{act}'
+        , 'expected ' + this._obj + ' to not have been called twice'
         , 2
         , this._obj.__spy.calls.length
       );
@@ -325,7 +376,7 @@
           this.assert(
               this._obj.__spy.calls.length > n
             , 'expected ' + this._obj + ' to have been called more than #{exp} times but got #{act}'
-            , 'expected ' + this._obj + ' to have been called no more than than #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called at most #{exp} times but got #{act}'
             , n
             , this._obj.__spy.calls.length
           );
@@ -354,7 +405,7 @@
 
           this.assert(
               this._obj.__spy.calls.length <  n
-            , 'expected ' + this._obj + ' to have been called less than #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called fewer than #{exp} times but got #{act}'
             , 'expected ' + this._obj + ' to have been called at least #{exp} times but got #{act}'
             , n
             , this._obj.__spy.calls.length
@@ -367,6 +418,66 @@
 
     Assertion.overwriteMethod('below', below);
     Assertion.overwriteMethod('lt', below);
+
+    /**
+     * # min (n)
+     *
+     * Assert that a spy has been called `n` or more times.
+     *
+     * @param {Number} n times
+     * @api public
+     */
+
+    function min (_super) {
+      return function (n) {
+        if ('undefined' !== typeof this._obj.__spy) {
+          new Assertion(this._obj).to.be.spy;
+
+          this.assert(
+              this._obj.__spy.calls.length >= n
+            , 'expected ' + this._obj + ' to have been called at least #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called fewer than #{exp} times but got #{act}'
+            , n
+            , this._obj.__spy.calls.length
+          );
+        } else {
+          _super.apply(this, arguments);
+        }
+      }
+    }
+
+    Assertion.overwriteMethod('min', min);
+    Assertion.overwriteMethod('least', min);
+
+    /**
+     * # max (n)
+     *
+     * Assert that a spy has been called `n` or fewer times.
+     *
+     * @param {Number} n times
+     * @api public
+     */
+
+    function max (_super) {
+      return function (n) {
+        if ('undefined' !== typeof this._obj.__spy) {
+          new Assertion(this._obj).to.be.spy;
+
+          this.assert(
+              this._obj.__spy.calls.length <=  n
+            , 'expected ' + this._obj + ' to have been called at most #{exp} times but got #{act}'
+            , 'expected ' + this._obj + ' to have been called more than #{exp} times but got #{act}'
+            , n
+            , this._obj.__spy.calls.length
+          );
+        } else {
+          _super.apply(this, arguments);
+        }
+      }
+    }
+
+    Assertion.overwriteMethod('max', max);
+    Assertion.overwriteMethod('most', max);
   };
 
 });

--- a/chai-spies.js
+++ b/chai-spies.js
@@ -123,7 +123,8 @@
      *
      *      var object = chai.spy.object('Array', [ 'push', 'pop' ]);
      *
-     * @param {Array|Object} method names or method definitions
+     * @param {String} [name] object name
+     * @param {String[]|Object} method names or method definitions
      * @returns object with spied methods
      * @api public
      */

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -107,7 +107,8 @@ module.exports = function (chai, _) {
    *
    *      var object = chai.spy.object('Array', [ 'push', 'pop' ]);
    *
-   * @param {Array|Object} method names or method definitions
+   * @param {String} [name] object name
+   * @param {String[]|Object} method names or method definitions
    * @returns object with spied methods
    * @api public
    */

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -81,6 +81,57 @@ module.exports = function (chai, _) {
   }
 
   /**
+   * # chai.spy.on (function)
+   *
+   * Wraps an object method into spy. All calls will
+   * pass through to the original function.
+   *
+   *      var spy = chai.spy.on(Array, 'isArray');
+   *
+   * @param {Object} object
+   * @param {String} method name to spy on
+   * @returns function to actually call
+   * @api public
+   */
+
+  chai.spy.on = function (object, methodName) {
+    object[methodName] = chai.spy(object[methodName]);
+
+    return object[methodName];
+  };
+
+  /**
+   * # chai.spy.object (function)
+   *
+   * Creates an object with spied methods.
+   *
+   *      var object = chai.spy.object('Array', [ 'push', 'pop' ]);
+   *
+   * @param {Array|Object} method names or method definitions
+   * @returns object with spied methods
+   * @api public
+   */
+
+  chai.spy.object = function (name, methods) {
+    var defs = {};
+
+    if (name && typeof name === 'object') {
+      methods = name;
+      name = 'object';
+    }
+
+    if (methods && !Array.isArray(methods)) {
+      defs = methods;
+      methods = Object.keys(methods);
+    }
+
+    return methods.reduce(function (object, methodName) {
+      object[methodName] = chai.spy(name + '.' + methodName, defs[methodName]);
+      return object;
+    }, {});
+  };
+
+  /**
    * # spy
    *
    * Assert the the object in question is an chai.spy

--- a/test/spies.js
+++ b/test/spies.js
@@ -208,6 +208,16 @@ describe('Chai Spies', function () {
     spyClean.should.have.length(0);
   });
 
+  it('spies specified object method', function() {
+    var array = [];
+
+    chai.spy.on(array, 'push');
+    array.push(1, 2);
+
+    array.push.should.be.a.spy;
+    array.should.have.length(2);
+  });
+
   describe('.with', function () {
     it('should not interfere chai with' ,function () {
       (1).should.be.with.a('number');
@@ -352,6 +362,32 @@ describe('Chai Spies', function () {
       (function () {
         spy2.should.have.been.always.called.with.exactly(4,4);
       }).should.throw(chai.AssertionError, /to have been always called with exactly/);
+    });
+  });
+
+  describe('spy object', function () {
+    it('should create spy object with specified method names', function () {
+      var object = chai.spy.object('array', [ 'push', 'pop' ]);
+
+      object.push.should.be.a.spy;
+      object.pop.should.be.a.spy;
+    });
+
+    it('should create spy object with specified method definitions', function () {
+      var object = chai.spy.object('array', {
+        push: function() {
+          return 'push';
+        }
+      });
+
+      object.push.should.be.a.spy;
+      object.push().should.equal('push');
+    });
+
+    it('should create spy object without name', function () {
+      var object = chai.spy.object([ 'push' ]);
+
+      object.push.should.be.a.spy;
     });
   });
 });

--- a/test/spies.js
+++ b/test/spies.js
@@ -366,16 +366,22 @@ describe('Chai Spies', function () {
   });
 
   describe('spy object', function () {
-    it('should create spy object with specified method names', function () {
+    it('should create a spy object with specified method names', function () {
       var object = chai.spy.object('array', [ 'push', 'pop' ]);
 
       object.push.should.be.a.spy;
       object.pop.should.be.a.spy;
     });
 
-    it('should create spy object with specified method definitions', function () {
+    it('should create an anonymous spy object', function () {
+      var object = chai.spy.object([ 'push' ]);
+
+      object.push.should.be.a.spy;
+    });
+
+    it('should create a spy object with specified method definitions', function () {
       var object = chai.spy.object('array', {
-        push: function() {
+        push: function () {
           return 'push';
         }
       });
@@ -384,10 +390,15 @@ describe('Chai Spies', function () {
       object.push().should.equal('push');
     });
 
-    it('should create spy object without name', function () {
-      var object = chai.spy.object([ 'push' ]);
+    it('should create an anonymous spy object with methods implementation', function () {
+      var object = chai.spy.object({
+        push: function () {
+          return 'push'
+        }
+      });
 
       object.push.should.be.a.spy;
+      object.push().should.equal('push');
     });
   });
 });


### PR DESCRIPTION
This pull request allows clients to create spy objects(mock objects):
```js
var storage = chai.spy.object('storage', [ 'getItem', 'setItem', 'removeItem' ]);

entityManager.useStorage(storage);
```
And simplifies spying of object methods
```js
// instead of writing
object.method = chai.spy(object.method);

// you can write 
chai.spy.on(object, 'method');
```