### PR TITLE
Improved interface of spy.on

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,19 @@ ee.on('some event', spy);
 var spy_again = chai.spy();
 ee.on('some other event', spy_again);
 
-//or you can track object methods calls
+// or you can track an object's method
 var array = [ 1, 2, 3 ];
 chai.spy.on(array, 'push');
+
+// or you can track multiple object's methods
+chai.spy.on(array, 'push', 'pop');
+
 array.push(5);
 
-//and you can reset the object calls
+// and you can reset the object calls
 array.push.reset();
 
-//or you can create spy object
+// or you can create spy object
 var object = chai.spy.object([ 'push', 'pop' ]);
 object.push(5);
 

--- a/chai-spies.js
+++ b/chai-spies.js
@@ -115,15 +115,19 @@
      *      var spy = chai.spy.on(Array, 'isArray');
      *
      * @param {Object} object
-     * @param {String} method name to spy on
-     * @returns function to actually call
+     * @param {...String} method names to spy on
+     * @returns passed object
      * @api public
      */
 
-    chai.spy.on = function (object, methodName) {
-      object[methodName] = chai.spy(object[methodName]);
+    chai.spy.on = function (object) {
+      var methodNames = Array.prototype.slice.call(arguments, 1);
 
-      return object[methodName];
+      methodNames.forEach(function(methodName) {
+        object[methodName] = chai.spy(object[methodName]);
+      });
+
+      return object;
     };
 
     /**

--- a/lib/spy.js
+++ b/lib/spy.js
@@ -99,15 +99,19 @@ module.exports = function (chai, _) {
    *      var spy = chai.spy.on(Array, 'isArray');
    *
    * @param {Object} object
-   * @param {String} method name to spy on
-   * @returns function to actually call
+   * @param {...String} method names to spy on
+   * @returns passed object
    * @api public
    */
 
-  chai.spy.on = function (object, methodName) {
-    object[methodName] = chai.spy(object[methodName]);
+  chai.spy.on = function (object) {
+    var methodNames = Array.prototype.slice.call(arguments, 1);
 
-    return object[methodName];
+    methodNames.forEach(function(methodName) {
+      object[methodName] = chai.spy(object[methodName]);
+    });
+
+    return object;
   };
 
   /**

--- a/test/spies.js
+++ b/test/spies.js
@@ -208,10 +208,8 @@ describe('Chai Spies', function () {
     spyClean.should.have.length(0);
   });
 
-  it('spies specified object method', function() {
-    var array = [];
-
-    chai.spy.on(array, 'push');
+  it('should spy specified object method', function () {
+    var array = chai.spy.on([], 'push');
     array.push(1, 2);
 
     array.push.should.be.a.spy;
@@ -224,6 +222,13 @@ describe('Chai Spies', function () {
 
     spy.should.be.a.spy;
     spy().should.equal(value);
+  });
+
+  it('should spy multiple object methods passed as array', function () {
+    var array = chai.spy.on([], 'push', 'pop');
+
+    array.push.should.be.a.spy;
+    array.pop.should.be.a.spy;
   });
 
   describe('.with', function () {


### PR DESCRIPTION
 Now it's possible to pass multiple methods in the second argument
```js
var array = [];
chai.spy(array, 'push pop');

// or
chai.spy(array, [ 'push', 'pop' ]);
```