### PR TITLE
Added ability to remove spies from object methods

### DIFF
--- a/lib/spy.js
+++ b/lib/spy.js
@@ -108,7 +108,21 @@ module.exports = function (chai, _) {
     var methodNames = Array.prototype.slice.call(arguments, 1);
 
     methodNames.forEach(function(methodName) {
-      object[methodName] = chai.spy(object[methodName]);
+      var originalMethod = object[methodName];
+      var spy = object[methodName] = chai.spy(originalMethod);
+
+      /**
+       * # chai.spy.removeSpy ()
+       * 
+       * Removes this spy from object method. Useful when spying on system APIs.
+       * Only exists in spies that installed with spy.on()
+       * 
+       *     var spy = chai.spy.on(console, 'log');
+       *     console.log.removeSpy();
+       */
+      spy.removeSpy = function() {
+        object[methodName] = originalMethod;
+      }
     });
 
     return object;

--- a/test/spies.js
+++ b/test/spies.js
@@ -444,4 +444,21 @@ describe('Chai Spies', function () {
       spy.__spy.name.should.be.equal(name);
     });
   });
+
+  describe('remove method', function() {
+    it('should remove spy from object', function() {
+      var testObj = {
+        testMethod: function() { return "foo"; }
+      };
+
+      chai.spy.on(testObj, "testMethod");
+      var spy = testObj.testMethod;
+      testObj.testMethod();
+      spy.should.have.been.called.once;     // triggers when spy is installed
+
+      spy.removeSpy();
+      testObj.testMethod();
+      spy.should.have.been.called.once;    // does not trigger when spy is removed
+    });
+  });
 });


### PR DESCRIPTION
Feature is useful when you need to spy on system/browser APIs and restore it after test is done.

Test case for new functionality is included.