### PR TITLE
Update GitHub reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.7.1",
   "repository": {
     "type": "git",
-    "url": "git://github.com/logicalparadox/chai-spies.git"
+    "url": "git://github.com/chaijs/chai-spies.git"
   },
   "main": "./index",
   "scripts": {


### PR DESCRIPTION
The GitHub URL ( https://www.npmjs.com/package/chai-spies ) on NPM currently leads to a 404. Let's update to the organization url.