### PR TITLE
Added spy.returnsInOrder method

### DIFF
--- a/lib/spy.js
+++ b/lib/spy.js
@@ -165,6 +165,27 @@ module.exports = function (chai, _) {
   };
 
   /**
+   * # chai.spy.returnsInOrder (function)
+   *
+   * Creates a spy which returns different value each time it is called (in defined order).
+   *
+   *      var method = chai.spy.returnsInOrder(['first', 'second']);
+   *      method().should.equal('first');
+   *      method().should.equal('second');
+   *
+   * @param {Object[]} [values] array of values be returned by the spy
+   * @returns new spy function which returns values in given order
+   * @api public
+   */
+
+  chai.spy.returnsInOrder = function (values) {
+    var currentIndex = 0;
+    return chai.spy(function () {
+      return values[currentIndex++];
+    });
+  };
+
+  /**
    * # spy
    *
    * Assert the the object in question is an chai.spy

--- a/test/spies.js
+++ b/test/spies.js
@@ -224,6 +224,15 @@ describe('Chai Spies', function () {
     spy().should.equal(value);
   });
 
+  it('should create spy which returns multiple different values in order', function(){
+    var values = ['value1', 'value2']
+    var spy = chai.spy.returnsInOrder(values);
+
+    spy.should.be.a.spy;
+    spy().should.equal(values[0]);
+    spy().should.equal(values[1]);
+  });
+
   it('should spy multiple object methods passed as array', function () {
     var array = chai.spy.on([], 'push', 'pop');
 


### PR DESCRIPTION
Hello *,

this is an extensions for the new **returns** method, but in this case it allows the spy to return multiple different values in given order. Example usage:

```javascript
var spy = chai.spy.returnsInOrder('first', 'second');
spy().should.equal('first');
spy().should.equal('second');
```

I had to add it for the project I'm working on. It can be helpful, for instance, when you pass a spy to another object which uses it in a loop.