### PR TITLE
Use stable node version in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: node_js
 node_js:
+- 0.1
+- 4.3
 - stable
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- 0.1
+- stable
 
 script:
 - make test


### PR DESCRIPTION
Hello,

So TravisCI prints out warnings caused by the old version of Node being used.