### PR TITLE
Fix .with() chainable method for multiple arguments

### DIFF
--- a/lib/spy.js
+++ b/lib/spy.js
@@ -272,12 +272,12 @@ module.exports = function (chai, _) {
     if (always) {
       passed = 0
       calls.forEach(function (call) {
+        if (call.length !== args.length) return;
         var found = 0;
-        args.forEach(function (arg) {
-          for (var i = 0; i < call.length; i++) {
-            if (_.eql(call[i], arg)) found++;
-          }
-        });
+        for (var i = 0; i < call.length; i++) {
+          if (_.eql(call[i], args[i])) found++;
+        }
+  
         if (found === args.length) passed++;
       });
 
@@ -290,12 +290,12 @@ module.exports = function (chai, _) {
     } else {
       passed = 0;
       calls.forEach(function (call) {
+        if (call.length !== args.length) return;
         var found = 0;
-        args.forEach(function (arg) {
-          for (var i = 0; i < call.length; i++) {
-            if (_.eql(call[i], arg)) found++;
-          }
-        });
+        for (var i = 0; i < call.length; i++) {
+          if (_.eql(call[i], args[i])) found++;
+        }
+  
         if (found === args.length) passed++;
       });
 


### PR DESCRIPTION
Unless I'm wrong about the API, if I create a spy, call it like

        object.spy(5, 5, 3, 1, 8);

and then assert

        expect(object.spy).to.have.been.called.with(5, 5, 3, 1, 8)

it should pass. The problem is that the current code will compare each argument of the assertion with each argument of the actual call 5 times, and will fail with repeated arguments, because found > args.length. Looks like a bug to me, but I haven't seen examples of .with() with multiple arguments.