### PR TITLE
Fix .with when multiple identical arguments

### DIFF
--- a/lib/spy.js
+++ b/lib/spy.js
@@ -264,46 +264,40 @@ module.exports = function (chai, _) {
 
   function assertWith () {
     new Assertion(this._obj).to.be.spy;
-    var args = [].slice.call(arguments, 0)
+    var expArgs = [].slice.call(arguments, 0)
       , calls = this._obj.__spy.calls
       , always = _.flag(this, 'spy always')
-      , passed;
+      , passed = 0;
+
+    calls.forEach(function (call) {
+      var actArgs = call.slice()
+        , found = 0;
+
+      expArgs.forEach(function (expArg) {
+        for (var i = 0; i < actArgs.length; i++) {
+          if (_.eql(actArgs[i], expArg)) {
+            found++;
+            actArgs.splice(i, 1);
+            break;
+          }
+        }
+      });
+      if (found === expArgs.length) passed++;
+    });
 
     if (always) {
-      passed = 0
-      calls.forEach(function (call) {
-        var found = 0;
-        args.forEach(function (arg) {
-          for (var i = 0; i < call.length; i++) {
-            if (_.eql(call[i], arg)) found++;
-          }
-        });
-        if (found === args.length) passed++;
-      });
-
       this.assert(
           passed === calls.length
         , 'expected ' + this._obj + ' to have been always called with #{exp} but got ' + passed + ' out of ' + calls.length
-        , 'expected ' + this._his + ' to have not always been called with #{exp}'
-        , args
+        , 'expected ' + this._obj + ' to have not always been called with #{exp}'
+        , expArgs
       );
     } else {
-      passed = 0;
-      calls.forEach(function (call) {
-        var found = 0;
-        args.forEach(function (arg) {
-          for (var i = 0; i < call.length; i++) {
-            if (_.eql(call[i], arg)) found++;
-          }
-        });
-        if (found === args.length) passed++;
-      });
-
       this.assert(
           passed > 0
         , 'expected ' + this._obj + ' to have been called with #{exp}'
-        , 'expected ' + this._his + ' to have not been called with #{exp} but got ' + passed + ' times'
-        , args
+        , 'expected ' + this._obj + ' to have not been called with #{exp} but got ' + passed + ' times'
+        , expArgs
       );
     }
   }

--- a/test/spies.js
+++ b/test/spies.js
@@ -276,6 +276,15 @@ describe('Chai Spies', function () {
         spy.should.have.not.been.called.with(3,6,9);
       }).should.throw(chai.AssertionError, /have not been called with/);
     });
+
+    it('should pass when called with multiple identical arguments', function () {
+      var spy = chai.spy();
+      spy(1, 1);
+      spy.should.have.been.called.with(1);
+      spy.should.have.been.called.with(1, 1);
+      spy.should.not.have.been.called.with(1, 2);
+      spy.should.not.have.been.called.with(1, 1, 1);
+    });
   });
 
   describe('.always.with(arg, ...)', function () {
@@ -312,6 +321,16 @@ describe('Chai Spies', function () {
         spy.should.not.have.been.always.called.with(1,2);
       }).should.throw(chai.AssertionError, /to have not always been called with/);
     });
+
+    it('should pass when called with multiple identical arguments', function () {
+      var spy = chai.spy();
+      spy(1, 3, 1);
+      spy(1, 2, 1);
+      spy.should.have.always.been.called.with(1);
+      spy.should.have.always.been.called.with(1, 1);
+      spy.should.not.have.always.been.called.with(1, 2);
+      spy.should.not.have.always.been.called.with(1, 1, 1);
+    });
   });
 
   describe('.with.exactly(arg, ...)', function () {
@@ -341,6 +360,15 @@ describe('Chai Spies', function () {
       (function () {
         spy.should.have.not.been.called.with.exactly(3,2);
       }).should.throw(chai.AssertionError, /to not have been called with exactly/);
+    });
+
+    it('should pass when called with multiple identical arguments', function () {
+      var spy = chai.spy();
+      spy(1, 1);
+      spy.should.have.been.called.with.exactly(1, 1);
+      spy.should.not.have.been.called.with.exactly(1);
+      spy.should.not.have.been.called.with.exactly(1, 2);
+      spy.should.not.have.been.called.with.exactly(1, 1, 1);
     });
   });
 
@@ -375,6 +403,16 @@ describe('Chai Spies', function () {
       (function () {
         spy2.should.have.been.always.called.with.exactly(4,4);
       }).should.throw(chai.AssertionError, /to have been always called with exactly/);
+    });
+
+    it('should pass when called with multiple identical arguments', function () {
+      var spy = chai.spy();
+      spy(1, 1);
+      spy(1, 1);
+      spy.should.have.always.been.called.with.exactly(1, 1);
+      spy.should.not.have.always.been.called.with.exactly(1);
+      spy.should.not.have.always.been.called.with.exactly(1, 2);
+      spy.should.not.have.always.been.called.with.exactly(1, 1, 1);
     });
   });
 


### PR DESCRIPTION
- Fixes https://github.com/chaijs/chai-spies/issues/45
- Fixes expected value in failed assertion message
- Refactors code that was duplicated between both logic branches of `.always`