### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Spies for the Chai assertion library.",
   "keywords": ["chai", "chai-plugin", "browser", "mocks-and-spies", "testing", "spies", "stubs", "mocks"],
   "version": "0.7.1",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/chaijs/chai-spies.git"


### PR DESCRIPTION
It would be awesome if the license would be available through the NPMRegistry. I'm working on [VersionEye](https://www.versioneye.com) and for us the license information is very important. 