### PR TITLE
refactor(spy): removes reset method

### DIFF
--- a/lib/spy.js
+++ b/lib/spy.js
@@ -217,23 +217,14 @@ module.exports = function (chai, _) {
       s += " }";
       return s;
     };
+    
+    proxy.__spy = {
+      calls: []
+      , called: false
+      , name: name
+    };
 
-  /**
-   * # proxy.reset (function)
-   *
-   * Resets spy's state object parameters for instantiation and reuse
-   * @returns proxy spy object
-   */
-    proxy.reset = function() {
-      this.__spy = {
-        calls: []
-        , called: false
-        , name: name
-      };
-      return this;
-    }
-
-    return proxy.reset();
+    return proxy;
   }
 
   /**

--- a/test/spies.js
+++ b/test/spies.js
@@ -484,36 +484,6 @@ describe('Chai Spies', function () {
     });
   });
 
-  describe('reset method', function () {
-    it('should reset spy object values to defaults when called', function() {
-      var name = 'proxy';
-      var spy = chai.spy(name);
-
-      spy();
-      spy.should.have.been.called();
-      spy.__spy.called.should.be.true;
-      spy.__spy.calls.should.have.length(1);
-      spy.__spy.name.should.be.equal(name);
-
-      spy.reset();
-
-      spy.should.not.have.been.called();
-      spy.__spy.called.should.be.false;
-      spy.__spy.calls.should.have.length(0);
-      spy.__spy.name.should.be.equal(name);
-    });
-
-    it('should setup spy with default values when spy is instantiated', function() {
-      var name     = 'proxy';
-      var spy      = chai.spy(name);
-
-      spy.should.be.spy;
-      spy.__spy.called.should.be.false;
-      spy.__spy.calls.should.have.length(0);
-      spy.__spy.name.should.be.equal(name);
-    });
-  });
-
   describe('spy restore', function () {
     var array;
 


### PR DESCRIPTION
Spy should remain immutable. Instead of `reset`ing it, it's better to create a new one