### PR TITLE
Remove link to very dead project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Chai Spies
 
 This is an addon plugin for the [chai](https://github.com/chaijs/chai) assertion library. It provides the
-most basic function spy ability and tests. Though useful for small modules, you are probably going to want something
-more robust. Check out [jack](http://github.com/vesln/jack) for a full featured mock/stub/spy assertion library for use with chai.
+most basic function spy ability and tests.
 
 This library is primarily meant to serve as a starting point for anyone interested in developing chai plugins. If
 developing a module, you are welcome to use this as a starting point. I also encourage the use of the compile


### PR DESCRIPTION
Jack hasn't been touched in four years; probably should not refer users to it.