### PR TITLE
Updating the readme examples to use chai.spy.interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ array.push(5);
 array.push.reset();
 
 // or you can create spy object
-var object = chai.spy.object([ 'push', 'pop' ]);
+var object = chai.spy.interface([ 'push', 'pop' ]);
 object.push(5);
 
 // or you create spy which returns static value


### PR DESCRIPTION
chai.spy.object() got removed in this commit: a2f6a8044bf6effc3558e1f71f1445aa91fc954c on the 16th of August, 2017. Presumably, chai.spy.interface() is its replacement?