### PR TITLE
chore(package): drop support for node 0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-- 0.1
 - 4.3
 - stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 language: node_js
 node_js:
-- 4.3
-- stable
+  - 4 # to be removed 2018-04-01
+  - 6 # to be removed 2019-04-01
+  - 7 # to be removed 2017-06-30
+  - lts/* # safety net; don't remove
+  - node # safety net; don't remove
 
 script:
 - npm run test.only

--- a/package.json
+++ b/package.json
@@ -29,10 +29,13 @@
   "engines": {
     "node": ">= 4.0.0"
   },
+  "peerDependencies": {
+    "chai": "*"
+  },
   "devDependencies": {
     "chai": "*",
     "mocha": "*",
-    "rollup": "^0.47.4",
-    "rollup-plugin-commonjs": "^8.1.0"
+    "rollup": "^0.53.3",
+    "rollup-plugin-commonjs": "^8.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,14 +27,12 @@
     "build": "rollup -c support/compile.js"
   },
   "engines": {
-    "node": ">= 0.4.0"
+    "node": ">= 4.0.0"
   },
-  "dependencies": {},
   "devDependencies": {
     "chai": "*",
     "mocha": "*",
     "rollup": "^0.47.4",
     "rollup-plugin-commonjs": "^8.1.0"
-  },
-  "optionalDependencies": {}
+  }
 }

--- a/support/compile.js
+++ b/support/compile.js
@@ -2,9 +2,9 @@ import commonjs from 'rollup-plugin-commonjs';
 
 const MODULE_NAME = '__chaiSpies__'
 
-function injectChaiPresenceCheck() {
+function replaceGlobalExportWithChaiUse() {
   return {
-    name: 'chai-presence-check',
+    name: 'chai-use',
 
     transformBundle(source, options) {
       return source.replace(
@@ -21,13 +21,14 @@ function injectChaiPresenceCheck() {
 }
 
 export default {
-  entry: 'lib/spy.js',
-  dest: './chai-spies.js',
-  format: 'umd',
-  exports: 'default',
-  moduleName: MODULE_NAME,
+  input: 'lib/spy.js',
+  output: {
+    format: 'umd',
+    name: MODULE_NAME,
+    file: './chai-spies.js'
+  },
   plugins: [
     commonjs(),
-    injectChaiPresenceCheck()
+    replaceGlobalExportWithChaiUse()
   ]
 };


### PR DESCRIPTION
Rollup plugins and latest mocha doesn't support 0.x version of node

Fixes #85, Fixes #83