### PR TITLE
Drop NODE_AUTH_TOKEN from publish script, update versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 25
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm install -g npm@latest
@@ -25,5 +25,3 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
       - run: npm whoami; npm --ignore-scripts publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,4 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish --provenance --access public
+      - run: npm --ignore-scripts publish --provenance --access public


### PR DESCRIPTION
This now uses OIDC for publishing